### PR TITLE
Fixed invalid generated URI when using debian

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -26,6 +26,7 @@ when "rhel", "fedora"
 when "suse"
   default['mariadb']['client']['packages'] = %w{mariadb-community-server-client libmariadbclient-devel}
 when "debian"
+  default['mariadb']['version'] = "5.5"
   if debian_before_squeeze? || ubuntu_before_lucid?
     default['mariadb']['client']['packages'] = %w{mariadb-client libmariadbclient15-dev}
   else

--- a/recipes/mariadb_repo.rb
+++ b/recipes/mariadb_repo.rb
@@ -29,7 +29,7 @@ when "debian"
   include_recipe "apt"
 
   apt_repository "mariadb" do
-    uri "http://ftp.osuosl.org/pub/mariadb/repo/#{node[:mariadb][:version]}/debian n"
+    uri "http://ftp.osuosl.org/pub/mariadb/repo/#{node[:mariadb][:version]}/debian"
     distribution node['lsb']['codename']
     components ['main']
     keyserver "keyserver.ubuntu.com"


### PR DESCRIPTION
This commit will fix https://github.com/joerocklin/chef-mariadb/issues/2
