### PR TITLE
Add fedora support

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -22,8 +22,10 @@
 ::Chef::Node.send(:include, Opscode::Mysql::Helpers)
 
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel'
   default['mariadb']['client']['packages'] = %w{MariaDB-client MariaDB-devel}
+when 'fedora'
+  default['mariadb']['client']['packages'] = %w{mariadb mariadb-devel}
 when 'suse'
   default['mariadb']['client']['packages'] = %w{mariadb-community-server-client libmariadbclient-devel}
 when 'debian'

--- a/attributes/server_fedora.rb
+++ b/attributes/server_fedora.rb
@@ -6,7 +6,7 @@ when 'fedora'
   default['mariadb']['data_dir'] = '/var/lib/mysql'
 
   # Setup the install package and the slow query logging
-  default['mariadb']['server']['packages'] = ['MariaDB-server']
+  default['mariadb']['server']['packages'] = ['mariadb-server']
   default['mariadb']['server']['slow_query_log']       = 1
   default['mariadb']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'
 
@@ -26,7 +26,7 @@ when 'fedora'
   default['mariadb']['server']['socket']               = '/var/lib/mysql/mysql.sock'
   default['mariadb']['server']['grants_path']          = '/etc/mysql_grants.sql'
   default['mariadb']['server']['old_passwords']        = 1
-  default['mariadb']['server']['service_name']        = 'mysql'
+  default['mariadb']['server']['service_name']        = 'mariadb'
 
   # RHEL/CentOS mysql package does not support this option.
   default['mariadb']['tunable']['innodb_adaptive_flushing'] = false

--- a/attributes/server_fedora.rb
+++ b/attributes/server_fedora.rb
@@ -1,0 +1,34 @@
+case node['platform_family']
+when 'fedora'
+
+  # Probably driven from wrapper cookbooks, environments, or roles.
+  # Keep in this namespace for backwards compat
+  default['mariadb']['data_dir'] = '/var/lib/mysql'
+
+  # Setup the install package and the slow query logging
+  default['mariadb']['server']['packages'] = ['MariaDB-server']
+  default['mariadb']['server']['slow_query_log']       = 1
+  default['mariadb']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'
+
+  # Platformisms.. filesystem locations and such.
+  default['mariadb']['server']['basedir'] = '/usr'
+  default['mariadb']['server']['tmpdir'] = ['/tmp']
+
+  default['mariadb']['server']['directories']['run_dir']              = '/var/run/mysqld'
+  default['mariadb']['server']['directories']['log_dir']              = '/var/lib/mysql'
+  default['mariadb']['server']['directories']['slow_log_dir']         = '/var/log/mysql'
+  default['mariadb']['server']['directories']['confd_dir']            = '/etc/mysql/conf.d'
+
+  default['mariadb']['server']['mysqladmin_bin']       = '/usr/bin/mysqladmin'
+  default['mariadb']['server']['mysql_bin']            = '/usr/bin/mysql'
+
+  default['mariadb']['server']['pid_file']             = '/var/run/mysqld/mysqld.pid'
+  default['mariadb']['server']['socket']               = '/var/lib/mysql/mysql.sock'
+  default['mariadb']['server']['grants_path']          = '/etc/mysql_grants.sql'
+  default['mariadb']['server']['old_passwords']        = 1
+  default['mariadb']['server']['service_name']        = 'mysql'
+
+  # RHEL/CentOS mysql package does not support this option.
+  default['mariadb']['tunable']['innodb_adaptive_flushing'] = false
+  default['mariadb']['server']['skip_federated'] = false
+end

--- a/recipes/mariadb_repo.rb
+++ b/recipes/mariadb_repo.rb
@@ -37,7 +37,7 @@ when 'debian'
     action :add
   end
 
-when 'rhel', 'fedora'
+when 'rhel'
   include_recipe 'yum'
 
   arch = node['kernel']['machine']
@@ -51,4 +51,9 @@ when 'rhel', 'fedora'
     baseurl     "http://yum.mariadb.org/#{node['mariadb']['version']}/#{node['platform']}#{pversion}-#{arch}"
     gpgkey      'https://yum.mariadb.org/RPM-GPG-KEY-MariaDB'
   end
+when 'fedora'
+  # Fedora provides MariaDB as part of the system's default repositories
+  # Additionally, MariaDB's amd64 repository has issues on Fedora x86_64
+  # https://mariadb.atlassian.net/browse/MDEV-5152
+  # So just use the system repositories
 end

--- a/recipes/mariadb_repo.rb
+++ b/recipes/mariadb_repo.rb
@@ -41,6 +41,8 @@ when 'rhel', 'fedora'
   include_recipe 'yum'
 
   arch = node['kernel']['machine']
+  # Fedora reports the architecture as 'x86_64'
+  arch = 'amd64' if arch == 'x86_64'
   arch = 'x86' unless arch == 'amd64'
   pversion = node['platform_version'].split('.').first
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -76,7 +76,7 @@ template "#{node['mariadb']['data_dir']}/replication_slave_script" do
 end
 
 case node['platform_family']
-when 'rhel'
+when 'rhel', 'fedora'
   include_recipe 'mariadb::_server_rhel'
 when 'debian'
   include_recipe 'mariadb::_server_debian'


### PR DESCRIPTION
For x86_64, MariaDB 5.5 has a bug in their repo (see: https://mariadb.atlassian.net/browse/MDEV-5152).
Additionally, Fedora packages MariaDB as its default version of "MySQL"
This adds the fedora platform_family in the places that's needed and switches to the system packages.
The system package switch can be undone later when the above bug is fixed, if desired (currently slated for MariaDB 5.6)
