### PR TITLE
Add the mysql gem for the database cookbook

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -29,3 +29,6 @@ node['mariadb']['client']['packages'].each do |name|
 end
 
 chef_gem 'mysql2'
+
+# The database cookbook needs the mysql gem
+chef_gem 'mysql'


### PR DESCRIPTION
The database cookbook (http://community.opscode.com/cookbooks/database) uses the mysql gem.  It needs to be installed for MariaDB to function as a drop-in replacement for MySQL with that cookbook.
