### PR TITLE
fix for user/group mismatch in recipes/server_ec2.rb

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -23,6 +23,10 @@ default['mariadb']['bind_address']              = node.attribute?('cloud') ? nod
 default['mariadb']['port']                      = 3306
 default['mariadb']['nice']                      = 0
 
+# service/daemon user/group
+default['mariadb']['service']['user']                  = 'mysql'
+default['mariadb']['service']['group']                 = 'mysql'
+
 # eventually remove?  where is this used?
 if attribute?('ec2')
   default['mariadb']['ec2_path']    = '/mnt/mysql'

--- a/recipes/server_ec2.rb
+++ b/recipes/server_ec2.rb
@@ -29,8 +29,8 @@ if node.attribute?('ec2') && !FileTest.directory?(node['mariadb']['ec2_path'])
 
   [node['mariadb']['ec2_path'], node['mariadb']['data_dir']].each do |dir|
     directory dir do
-      owner 'mariadb'
-      group 'mariadb'
+      owner node['mariadb']['service']['user']
+      group node['mariadb']['service']['group']
     end
   end
 

--- a/templates/ubuntu-10/init-mysql.conf.erb
+++ b/templates/ubuntu-10/init-mysql.conf.erb
@@ -24,7 +24,7 @@ pre-start script
     if aa-status --enabled 2>/dev/null; then
         apparmor_parser -r /etc/apparmor.d/usr.sbin.mysqld || true
     fi
-    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
+    LC_ALL=C BLOCKSIZE= df --portability <%= node['mariadb']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
 end script
 
 exec /usr/sbin/mysqld

--- a/templates/ubuntu-12/init-mysql.conf.erb
+++ b/templates/ubuntu-12/init-mysql.conf.erb
@@ -20,7 +20,7 @@ pre-start script
     [ -r $HOME/my.cnf ]
     [ -d /var/run/mysqld ] || install -m 755 -o mysql -g root -d /var/run/mysqld
     /lib/init/apparmor-profile-load usr.sbin.mysqld
-    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
+    LC_ALL=C BLOCKSIZE= df --portability <%= node['mariadb']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
 end script
 
 exec /usr/sbin/mysqld


### PR DESCRIPTION
mariadb::server will install with user/group owner of 'mysql' by default, while recipe/server_ec2.rb expects  user & group to be 'mariadb'.

this patch allows recipes/server_ec2.rb to use two new default options set in attributes/server.rb:

default['mariadb']['service']['user']                  = 'mysql'
default['mariadb']['service']['group']                = 'mysql'

recipes/server.rb should also be refactored to support custom user/group.
