### PR TITLE
Build-essential tagged 2.0.x versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -30,4 +30,4 @@ depends 'yum-epel'
 depends 'apt',              '~> 2.0'
 
 depends 'openssl',          '~> 1.1'
-depends 'build-essential',  '~> 1.4'
+depends 'build-essential',  '> 1.4'


### PR DESCRIPTION
~> 1.4 throwed unresolvable dependency tree errors because some other cookbooks upped their build-essential dependency version.

https://github.com/opscode-cookbooks/build-essential/blob/master/CHANGELOG.md#v200-2014-03-13
