### PR TITLE
flag to disable repo configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 
-  default['mariadb']['version'] = '5.5'
+default['mariadb']['version'] = '5.5'
+default['mariadb']['disable_repo'] = false

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -21,7 +21,7 @@
 # to debian_before_squeeze? and ubuntu_before_lucid?
 ::Chef::Recipe.send(:include, Opscode::Mysql::Helpers)
 
-include_recipe 'mariadb::mariadb_repo'
+include_recipe 'mariadb::mariadb_repo' unless node['mariadb']['disable_repo'] == true
 
 # On RHEL platforms, yum isn't happy to have MariaDB and mysql-libs coexisting
 package 'mysql-libs' do

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -21,7 +21,9 @@
 # to debian_before_squeeze? and ubuntu_before_lucid?
 ::Chef::Recipe.send(:include, Opscode::Mysql::Helpers)
 
-include_recipe 'mariadb::mariadb_repo' unless node['mariadb']['disable_repo'] == true
+unless node['mariadb']['disable_repo'] == true
+  include_recipe 'mariadb::mariadb_repo'
+end
 
 # On RHEL platforms, yum isn't happy to have MariaDB and mysql-libs coexisting
 package 'mysql-libs' do


### PR DESCRIPTION
- In some environments, there's no need to pull packages from the
  upstream repository as there's one local. this flags allow to disable
  the repo configuration.
