### PR TITLE
Add gem provider, fixes #12

### DIFF
--- a/libraries/provider_mariadb_chef_gem.rb
+++ b/libraries/provider_mariadb_chef_gem.rb
@@ -1,0 +1,54 @@
+class Chef
+  class Provider
+    class MariadbChefGem < Chef::Provider::LWRPBase
+      use_inline_resources if defined?(use_inline_resources)
+
+      def whyrun_supported?
+        true
+      end
+
+      def action_install
+        converge_by 'install mysql chef_gem and dependencies' do
+
+          recipe_eval do
+            run_context.include_recipe 'build-essential::default'
+            run_context.include_recipe 'mariadb::client'
+          end
+
+          recipe_eval do
+            node['mariadb']['client']['packages'].each do |p|
+              package p do
+                action :install
+              end
+            end
+          end
+
+          chef_gem 'mysql2' do
+            action :install
+          end
+
+          chef_gem 'mysql' do
+            action :install
+          end
+
+        end
+      end
+
+      def action_remove
+
+        recipe_eval do
+          %w(mariadb-client libmariadbclient-dev).each do |p|
+            package p do
+              action :remove
+            end
+          end
+        end
+
+        chef_gem 'mysql' do
+          action :remove
+        end
+
+      end
+    end
+  end
+end

--- a/libraries/provider_mariadb_chef_gem.rb
+++ b/libraries/provider_mariadb_chef_gem.rb
@@ -37,7 +37,7 @@ class Chef
       def action_remove
 
         recipe_eval do
-          %w(mariadb-client libmariadbclient-dev).each do |p|
+          node['mariadb']['client']['packages'].each do |p|
             package p do
               action :remove
             end

--- a/libraries/resource_mariadb_chef_gem.rb
+++ b/libraries/resource_mariadb_chef_gem.rb
@@ -1,0 +1,11 @@
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class MariadbChefGem < Chef::Resource::LWRPBase
+      self.resource_name = :mariadb_chef_gem
+      actions  :install, :remove
+      default_action :install
+    end
+  end
+end

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -20,15 +20,6 @@
 # limitations under the License.
 #
 
-node.set['build-essential']['compiletime'] = true
-include_recipe 'build-essential::default'
-include_recipe 'mariadb::client'
-
-node['mariadb']['client']['packages'].each do |name|
-  resources("package[#{name}]").run_action(:install)
+mariadb_chef_gem "default" do
+  action :install
 end
-
-chef_gem 'mysql2'
-
-# The database cookbook needs the mysql gem
-chef_gem 'mysql'


### PR DESCRIPTION
This wraps the gem installation in a Chef::Provider::LWRPBase like in the mysql-chef_gem cookbook. This way, the repository will be added before the gem is installed.
